### PR TITLE
fix: added the ability to lock the cell edit controller

### DIFF
--- a/lib/src/widgets/worksheet_widget.dart
+++ b/lib/src/widgets/worksheet_widget.dart
@@ -1599,13 +1599,17 @@ class _WorksheetState extends State<Worksheet>
     if (ec == null) return;
 
     final currentValue = (widget.rawData ?? widget.data).getCell(cell);
-    ec.startEdit(
+    final started = ec.startEdit(
       cell: cell,
       currentValue: currentValue,
       trigger: trigger,
       initialText: initialText,
       tapPosition: tapPosition,
     );
+
+    if (!started) {
+      return;
+    }
 
     // Tell the tile painter to skip rendering text for this cell
     // (the overlay TextField renders it instead) and re-render the tile.


### PR DESCRIPTION
## Summary

I need to block editing of some cells (for example, fixed headers). The only solution I see is to override startEdit in EditController, but that doesn't help because the _startIntegratedEdit method, after calling editController.startEdit(...), always sets _tilePainter.editingRange, which causes the tile to stop rendering the cell text...

Although, it would be worth adding an edit lock to the cell settings...

```
class _DataOnlyEditController extends EditController {
  _DataOnlyEditController({required this.canEditCell});

  final bool Function(CellCoordinate cell) canEditCell;

  @override
  bool startEdit({
    required CellCoordinate cell,
    CellValue? currentValue,
    EditTrigger trigger = EditTrigger.programmatic,
    String? initialText,
    Offset? tapPosition,
  }) {
    if (!canEditCell(cell)) {
      return false;
    }
    return super.startEdit(
      cell: cell,
      currentValue: currentValue,
      trigger: trigger,
      initialText: initialText,
      tapPosition: tapPosition,
    );
  }
}
```

## Testing

- [x] `flutter test`
- [x] `dart analyze`
- [x] `dart format lib/ test/`

## Checklist

- [ ] Tests added or updated
- [ ] Docs updated if behavior or API changed
- [ ] Benchmarks updated if you touched O(N) or rendering code
