### PR TITLE
fix: loss of mergedCells with re-init worksheet

### DIFF
--- a/lib/src/widgets/worksheet_widget.dart
+++ b/lib/src/widgets/worksheet_widget.dart
@@ -2369,6 +2369,9 @@ class _WorksheetState extends State<Worksheet>
       _dataSubscription?.cancel();
       // Remove listener before re-init (which adds it again)
       widget.editController?.removeListener(_onEditTextChanged);
+      // save mergedCells in re-init
+			_layoutSolver.mergedCells = widget.data.mergedCells;
+			_controller.selectionController.mergedCells = widget.data.mergedCells;
       final theme = WorksheetTheme.of(context);
       final devicePixelRatio = MediaQuery.of(context).devicePixelRatio;
       _tileManager.dispose();


### PR DESCRIPTION
## Summary

after rebuild
<img width="2444" height="326" alt="image" src="https://github.com/user-attachments/assets/1d0ddce3-46f3-42cd-905b-a29d3d0984b0" />

When changing data in didUpdateWidget, Worksheet recreates tiles and TilePainter and supplies them with the current widget.data.mergedCells, but LayoutSolver, created once in _initLayout, continued to store a reference to mergedCells of the old data instance.

## Testing

- [ ] `flutter test`
- [ ] `dart analyze`
- [ ] `dart format lib/ test/`

## Checklist

- [ ] Tests added or updated
- [ ] Docs updated if behavior or API changed
- [ ] Benchmarks updated if you touched O(N) or rendering code
