### PR TITLE
feature: add (bool) enableMove param

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -500,25 +500,26 @@ abstract class WorksheetActionContext {
 
 ### Worksheet Widget Properties
 
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
+| Property | Type | Default  | Description |
+|----------|------|----------|-------------|
 | `data` | `WorksheetData` | required | Data source for the worksheet |
-| `rawData` | `WorksheetData?` | null | Raw data source for editing. When set, the cell editor reads values from `rawData` instead of `data`, so formula wrappers can evaluate formulas for display while editing still shows the original formula text. Only affects cell editing — rendering, styling, clipboard, and formatting use `data`. |
-| `controller` | `WorksheetController?` | null | Controller for selection, zoom, scroll |
+| `rawData` | `WorksheetData?` | null     | Raw data source for editing. When set, the cell editor reads values from `rawData` instead of `data`, so formula wrappers can evaluate formulas for display while editing still shows the original formula text. Only affects cell editing — rendering, styling, clipboard, and formatting use `data`. |
+| `controller` | `WorksheetController?` | null     | Controller for selection, zoom, scroll |
 | `rowCount` | `int` | required | Total number of rows |
 | `columnCount` | `int` | required | Total number of columns |
-| `readOnly` | `bool` | `false` | Disables selection and editing |
-| `mobileMode` | `bool?` | `null` | Touch interaction mode. `null` = auto-detect (mobile on iOS/Android, desktop on macOS/Windows/Linux). `true` = force mobile. `false` = force desktop. See [MOBILE_INTERACTION.md](MOBILE_INTERACTION.md). |
-| `onEditCell` | `OnEditCellCallback?` | null | Called on double-tap / F2 |
-| `onCellTap` | `OnCellTapCallback?` | null | Called when a cell is tapped |
-| `onResizeRow` | `OnResizeRowCallback?` | null | Called during row resize |
-| `onResizeColumn` | `OnResizeColumnCallback?` | null | Called during column resize |
-| `shortcuts` | `Map<ShortcutActivator, Intent>?` | null | Override/add shortcut bindings |
-| `actions` | `Map<Type, Action<Intent>>?` | null | Override action implementations |
-| `dateParser` | `AnyDate?` | null | Custom date format detection |
-| `formatLocale` | `FormatLocale?` | null | Locale for number/date formatting |
-| `customRowHeights` | `Map<int, double>?` | null | Custom heights for specific rows |
-| `customColumnWidths` | `Map<int, double>?` | null | Custom widths for specific columns |
+| `readOnly` | `bool` | `false`  | Disables selection and editing |
+| `enableMove` | `bool` | `true`     | Disables cell move gestures |
+| `mobileMode` | `bool?` | `null`   | Touch interaction mode. `null` = auto-detect (mobile on iOS/Android, desktop on macOS/Windows/Linux). `true` = force mobile. `false` = force desktop. See [MOBILE_INTERACTION.md](MOBILE_INTERACTION.md). |
+| `onEditCell` | `OnEditCellCallback?` | null     | Called on double-tap / F2 |
+| `onCellTap` | `OnCellTapCallback?` | null     | Called when a cell is tapped |
+| `onResizeRow` | `OnResizeRowCallback?` | null     | Called during row resize |
+| `onResizeColumn` | `OnResizeColumnCallback?` | null     | Called during column resize |
+| `shortcuts` | `Map<ShortcutActivator, Intent>?` | null     | Override/add shortcut bindings |
+| `actions` | `Map<Type, Action<Intent>>?` | null     | Override action implementations |
+| `dateParser` | `AnyDate?` | null     | Custom date format detection |
+| `formatLocale` | `FormatLocale?` | null     | Locale for number/date formatting |
+| `customRowHeights` | `Map<int, double>?` | null     | Custom heights for specific rows |
+| `customColumnWidths` | `Map<int, double>?` | null     | Custom widths for specific columns |
 
 ### Usage Example
 

--- a/lib/src/interaction/gesture_handler.dart
+++ b/lib/src/interaction/gesture_handler.dart
@@ -327,7 +327,9 @@ class WorksheetGestureHandler {
     } else if (hit.isFillHandle) {
       _fillHandler.start(selectionController.selectedRange, position);
     } else if (hit.isSelectionBorder) {
-      _moveHandler.start(hit, selectionController.selectedRange);
+      if (_moveHandler.isEnabled) {
+        _moveHandler.start(hit, selectionController.selectedRange);
+      }
     } else if (hit.isResizeHandle) {
       _isResizing = true;
     } else if (hit.isCell) {
@@ -535,6 +537,7 @@ class WorksheetGestureHandler {
     final cell = hit.cell;
     if (cell == null || !selection.contains(cell)) return;
 
+		if (!_moveHandler.isEnabled) return;
     _moveHandler.longPressStart(cell, selection);
     _selectionBeforeDrag = selection;
     _dragStartPosition = position;

--- a/lib/src/interaction/gestures/move_drag_handler.dart
+++ b/lib/src/interaction/gestures/move_drag_handler.dart
@@ -49,6 +49,12 @@ class MoveDragHandler {
   /// Whether a move drag is in progress.
   bool get isMoving => _isMoving;
 
+	/// Whether move operations are enabled by callbacks wiring.
+	bool get isEnabled =>
+			onMovePreviewUpdate != null ||
+			onMoveComplete != null ||
+			onMoveCancel != null;
+
   /// Starts a move drag from a selection border hit.
   ///
   /// [hit] is the hit test result on the selection border.

--- a/lib/src/widgets/worksheet_widget.dart
+++ b/lib/src/widgets/worksheet_widget.dart
@@ -106,6 +106,12 @@ class Worksheet extends StatefulWidget {
   /// Whether the worksheet is read-only (no selection or editing).
   final bool readOnly;
 
+	/// Enables drag-and-drop move of selected cells (selection border / long-press).
+	///
+	/// When `false`, cell move gestures are disabled while selection/editing stay available.
+	final bool enableMove;
+
+
   /// Date format parser for type detection during editing and clipboard paste.
   ///
   /// Controls how text input is detected as dates. Uses [AnyDate] from the
@@ -235,6 +241,7 @@ class Worksheet extends StatefulWidget {
     this.customRowHeights,
     this.customColumnWidths,
     this.readOnly = false,
+    this.enableMove = true,
     this.dateParser,
     this.formatLocale,
     this.clipboardSerializer,
@@ -986,18 +993,18 @@ class _WorksheetState extends State<Worksheet>
               _selectionLayer.fillPreviewRange = null;
               setState(() {});
             },
-      onMovePreviewUpdate: widget.readOnly
+      onMovePreviewUpdate: (widget.readOnly || !widget.enableMove)
           ? null
           : (previewRange) {
               _selectionLayer.movePreviewRange = previewRange;
               setState(() {});
             },
-      onMoveComplete: widget.readOnly
+      onMoveComplete: (widget.readOnly || !widget.enableMove)
           ? null
           : (sourceRange, destination) {
               _performMove(sourceRange, destination);
             },
-      onMoveCancel: widget.readOnly
+      onMoveCancel: (widget.readOnly || !widget.enableMove)
           ? null
           : () {
               _selectionLayer.movePreviewRange = null;
@@ -2559,8 +2566,9 @@ class _WorksheetState extends State<Worksheet>
                               SystemMouseCursors.resizeColumn,
                             HitTestType.fillHandle =>
                               SystemMouseCursors.precise,
-                            HitTestType.selectionBorder =>
-                              SystemMouseCursors.grab,
+                             HitTestType.selectionBorder => widget.enableMove
+                                 ? SystemMouseCursors.grab
+                                 : SystemMouseCursors.basic,
                             HitTestType.cell => SystemMouseCursors.cell,
                             HitTestType.rowHeader => SystemMouseCursors.click,
                             HitTestType.columnHeader =>


### PR DESCRIPTION
## Summary

The cell movement gestures are rather crude, often trigger unintentionally, and aren't really needed for normal table use; there needs to be an option to disable them.

## Testing

- [ ] `flutter test`
- [ ] `dart analyze`
- [ ] `dart format lib/ test/`

## Checklist

- [ ] Tests added or updated
- [ ] Docs updated if behavior or API changed
- [ ] Benchmarks updated if you touched O(N) or rendering code
