### PR TITLE
Fix spreadsheet dark mode editor background

### DIFF
--- a/lib/src/widgets/worksheet_widget.dart
+++ b/lib/src/widgets/worksheet_widget.dart
@@ -3573,7 +3573,9 @@ class _WorksheetState extends State<Worksheet>
                             fontFamily:
                                 firstSpanStyle?.fontFamily ?? theme.fontFamily,
                             textColor: theme.textColor,
-                            backgroundColor: cellStyle.backgroundColor,
+                            backgroundColor:
+                                cellStyle.backgroundColor ??
+                                theme.cellBackgroundColor,
                             textAlign: _toTextAlign(
                               cellStyle.textAlignment ??
                                   (widget.data.getCell(cell) != null

--- a/test/widgets/cell_editor_overlay_test.dart
+++ b/test/widgets/cell_editor_overlay_test.dart
@@ -51,6 +51,7 @@ void main() {
     CellVerticalAlignment verticalAlignment = CellVerticalAlignment.middle,
     FormulaReferenceConfig? formulaReferenceConfig,
     void Function(LogicalKeyboardKey, bool)? onFormulaArrowKey,
+    Color? backgroundColor,
   }) {
     return MaterialApp(
       home: Scaffold(
@@ -80,6 +81,7 @@ void main() {
               verticalAlignment: verticalAlignment,
               formulaReferenceConfig: formulaReferenceConfig,
               onFormulaArrowKey: onFormulaArrowKey,
+              backgroundColor: backgroundColor,
             ),
           ],
         ),
@@ -2707,6 +2709,165 @@ void main() {
       await tester.pump();
 
       expect(navigated, isTrue);
+    });
+  });
+
+  group('backgroundColor (Worksheet integration)', () {
+    testWidgets('editor overlay uses cell backgroundColor when set', (
+      tester,
+    ) async {
+      const cellColor = Color(0xFFFFEB3B);
+      final data = SparseWorksheetData(rowCount: 100, columnCount: 26);
+      data.setStyle(
+        const CellCoordinate(0, 0),
+        const CellStyle(backgroundColor: cellColor),
+      );
+
+      final controller = WorksheetController();
+      final ec = EditController();
+
+      addTearDown(() {
+        controller.dispose();
+        ec.dispose();
+        data.dispose();
+      });
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(size: Size(800, 600)),
+            child: WorksheetTheme(
+              data: const WorksheetThemeData(),
+              child: SizedBox(
+                width: 800,
+                height: 600,
+                child: Worksheet(
+                  data: data,
+                  controller: controller,
+                  editController: ec,
+                  rowCount: 100,
+                  columnCount: 26,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      const cell = CellCoordinate(0, 0);
+      controller.selectCell(cell);
+      ec.startEdit(cell: cell, currentValue: data.getCell(cell));
+      await tester.pump();
+
+      final overlay = tester.widget<CellEditorOverlay>(
+        find.byType(CellEditorOverlay),
+      );
+      expect(
+        overlay.backgroundColor,
+        cellColor,
+        reason: 'overlay should use the cell style backgroundColor',
+      );
+    });
+
+    testWidgets(
+      'editor overlay falls back to theme cellBackgroundColor when cell has no backgroundColor',
+      (tester) async {
+        final data = SparseWorksheetData(rowCount: 100, columnCount: 26);
+        final controller = WorksheetController();
+        final ec = EditController();
+        final themeData = const WorksheetThemeData().copyWith(
+          cellBackgroundColor: Colors.green,
+        );
+
+        addTearDown(() {
+          controller.dispose();
+          ec.dispose();
+          data.dispose();
+        });
+
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: MediaQuery(
+              data: const MediaQueryData(size: Size(800, 600)),
+              child: WorksheetTheme(
+                data: themeData,
+                child: SizedBox(
+                  width: 800,
+                  height: 600,
+                  child: Worksheet(
+                    data: data,
+                    controller: controller,
+                    editController: ec,
+                    rowCount: 100,
+                    columnCount: 26,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        const cell = CellCoordinate(0, 0);
+        controller.selectCell(cell);
+        ec.startEdit(cell: cell, currentValue: data.getCell(cell));
+        await tester.pump();
+
+        final overlay = tester.widget<CellEditorOverlay>(
+          find.byType(CellEditorOverlay),
+        );
+        expect(
+          overlay.backgroundColor,
+          themeData.cellBackgroundColor,
+          reason: 'overlay should fall back to theme.cellBackgroundColor',
+        );
+      },
+    );
+  });
+
+  group('backgroundColor (CellEditorOverlay unit)', () {
+    testWidgets('renders ColoredBox with given backgroundColor', (
+      tester,
+    ) async {
+      const cellColor = Color(0xFFFF5733);
+      editController.startEdit(cell: const CellCoordinate(0, 0));
+
+      await tester.pumpWidget(
+        buildTestWidget(controller: editController, backgroundColor: cellColor),
+      );
+
+      final coloredBox = tester.widget<ColoredBox>(
+        find
+            .descendant(
+              of: find.byType(CellEditorOverlay),
+              matching: find.byType(ColoredBox),
+            )
+            .first,
+      );
+      expect(coloredBox.color, cellColor);
+    });
+
+    testWidgets('renders transparent ColoredBox when backgroundColor is null', (
+      tester,
+    ) async {
+      editController.startEdit(cell: const CellCoordinate(0, 0));
+
+      await tester.pumpWidget(
+        buildTestWidget(controller: editController, backgroundColor: null),
+      );
+
+      final coloredBox = tester.widget<ColoredBox>(
+        find
+            .descendant(
+              of: find.byType(CellEditorOverlay),
+              matching: find.byType(ColoredBox),
+            )
+            .first,
+      );
+      expect(coloredBox.color, const Color(0x00000000));
     });
   });
 }


### PR DESCRIPTION
## Summary
Fixes an issue where the cell editor background ignored the worksheet theme’s background color and reverted to white while editing.

<img width="389" height="165" alt="cell" src="https://github.com/user-attachments/assets/f5f90136-91ee-45e4-84a7-99634adab3f1" />

This issue could be reproduced with a custom worksheet theme such as:
```
WorksheetTheme(
  data: WorksheetThemeData.darkTheme.copyWith(
    cellBackgroundColor: Colors.black,
    textColor: Colors.grey,
  ),
)
```

## Testing

- [x] `flutter test`
- [x] `dart analyze`
- [x] `dart format lib/ test/`

Note: some golden test failures already existed prior to this change, and this PR does not introduce any additional golden regressions.

## Checklist

- [x] Tests added or updated
- [ ] Docs updated if behavior or API changed
- [ ] Benchmarks updated if you touched O(N) or rendering code
